### PR TITLE
Install python requirements.txt file properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This XML file does not appear to have any style information associated with it. 
 
     - Step 2 - Create a Lambda function
         - Open AWS Management console, type "lambda" into the "Find Service" search bar and enter
-        - Make sure you are in the same region as 
+        - Make sure you are in the same region as before (Singapore)
         - Hit "Create function" then check "Author from scratch"
         - Enter a name for "Function name" (e.g. RekognitionS3Function)
         - Choose Python 3.6 for Runtime

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This XML file does not appear to have any style information associated with it. 
     ```bash
     # Parameter -i followed by name of the processed image and -b followed by the processed images S3 bucket name are required
 
-    python3 url_gen.py -i <image_name> -b <processed_bucket_name>
+    python3 url_gen.py -i <processed_image_name> -b <processed_bucket_name>
     ```
  - Copy the URL prompted on console and paste it to your browser/send it to others
 

--- a/index.py
+++ b/index.py
@@ -22,8 +22,8 @@ if __name__=='__main__':
         CollectionId = COLLECTION,
         Image = {
             'S3Object': {
-                'Bucket': BUCKET,
-                'Name': IMAGE,
+                'Bucket': RAW_IMAGES_BUCKET,
+                'Name': RAW_IMAGE_NAME,
             }
         },
         DetectionAttributes = ['ALL'],
@@ -61,7 +61,7 @@ if __name__=='__main__':
     print("Emotion: " + str(emotion))
 
     # Get the image W x H 
-    img = cv2.imread(IMAGE,1)
+    img = cv2.imread(RAW_IMAGE_NAME, 1)
     imgHeight, imgWidth, channels= img.shape
 
     # Get bounding box values and turn it into drawing coordinates

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,6 @@ sudo yum install npm -y
 npm install -g c9
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py --user
-pip3 install —-user -r requirements.txt
+sudo python3 -m pip install -r requirements.txt
 
 echo "==========> Dependencies installed successfully."


### PR DESCRIPTION
If you just put `sudo pip3 install —-user -r requirements.txt` I was getting pip3 not found. This is a workaround for that.

https://stackoverflow.com/questions/30993086/pip3-command-not-found-but-python3-pip-is-already-installed